### PR TITLE
Resolve issues #11 and #12

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-    "presets": ["env"]
+    "presets": ["@babel/preset-env"]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,24 @@
     "build": "rollup -c",
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test:unit": "jest --no-cache"
+  },
+  "jest": {
+    "setupFiles": [
+      "<rootDir>/tests/global-mocks.js"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "vue"
+    ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
+    },
+    "transform": {
+      "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
+      ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
+    }
   },
   "repository": {
     "type": "git",
@@ -38,14 +55,28 @@
     "pouchdb-utils": "^6.4.3"
   },
   "devDependencies": {
+    "@babel/core": "^7.4.3",
+    "@babel/preset-env": "^7.4.3",
+    "@vue/babel-preset-app": "^3.6.0",
+    "@vue/test-utils": "^1.0.0-beta.29",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-preset-env": "^1.7.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
+    "jest": "^24.7.1",
+    "node-fetch": "^2.3.0",
+    "pouchdb-find": "^7.0.0",
+    "pouchdb-node": "^7.0.0",
     "rollup": "^1.7.4",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-commonjs": "^9.2.2",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^4.0.1",
-    "rollup-plugin-replace": "^2.1.1"
+    "rollup-plugin-replace": "^2.1.1",
+    "vue": "^2.6.10",
+    "vue-jest": "^3.0.4",
+    "vue-template-compiler": "^2.6.10",
+    "vue-test-utils": "^1.0.0-beta.11"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -747,36 +747,11 @@ import { isRemote } from 'pouchdb-utils';
         },
     };
 
-    function installSelectorReplicationPlugin() {
-        // This plugin enables selector-based replication
-        pouch.plugin(pouch => {
-            let oldReplicate = pouch.replicate;
-            pouch.replicate = (source, target, repOptions) => {
-                let sourceAjax = source._ajax;
-                source._ajax = (ajaxOps, callback) => {
-                    if (ajaxOps.url.includes('_selector')) {
-                        ajaxOps.url = ajaxOps.url.replace(
-                            'filter=_selector%2F_selector',
-                            'filter=_selector'
-                        );
-                        ajaxOps.method = 'POST';
-                        ajaxOps.body = {
-                            selector: repOptions.selector,
-                        };
-                    }
-                    return sourceAjax(ajaxOps, callback);
-                };
-                return oldReplicate(source, target, repOptions);
-            };
-        });
-    }
-
     let api = {
         mixin: vuePouch,
         install: (Vue, options) => {
             vue = Vue;
             pouch = (options && options.pouch) || PouchDB;
-            installSelectorReplicationPlugin();
             defaultDB = (options && options.defaultDB) || '';
 
             // In PouchDB v7.0.0 the debug() API was moved to a separate plugin.

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import { isRemote } from 'pouchdb-utils';
 
     let vuePouch = {
         // lifecycle hooks for mixin
-        function beforeCreate(){
+        beforeCreate(){
             var pouchOptions = this.$options.pouch;
   
             if (!pouchOptions) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,41 @@ import { isRemote } from 'pouchdb-utils';
 
     let vuePouch = {
         // lifecycle hooks for mixin
+        function beforeCreate(){
+            var pouchOptions = this.$options.pouch;
+  
+            if (!pouchOptions) {
+                return;
+            }
+
+            let oldDataFunc = this.$options.data;      
+
+            this.$options.data= function(vm) {
+                // get the Vue instance's data object from the constructor
+                var plainObject = oldDataFunc.call(vm, vm);
+
+                // map the pouch databases to an object in the Vue instance's data
+                Object.keys(pouchOptions).map(function (key) {
+
+                    var pouchFn = pouchOptions[key];
+                    if (typeof pouchFn !== 'function') {
+                        pouchFn = function () {
+                            return pouchOptions[key];
+                        };
+                    }
+
+                  if (typeof plainObject[key] === 'undefined') {
+                      plainObject[key] = null;
+                  }
+                
+                });
+
+                // return the Vue instance's data with the additional pouch objects
+                // the Vue instance's data will be made reactive before the 'created' lifecycle hook runs
+                return plainObject;
+            }
+
+          },        
         beforeDestroy() {
             Object.values(this._liveFeeds).map(lf => {
                 lf.cancel();

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,11 @@ import { isRemote } from 'pouchdb-utils';
                 return;
             }
 
+            if(!this.$options.data)
+            {
+                this.$options.data = function () { return { }}
+            }
+
             let oldDataFunc = this.$options.data;      
 
             this.$options.data= function(vm) {

--- a/tests/ExistingTodosDataFunction.vue
+++ b/tests/ExistingTodosDataFunction.vue
@@ -1,0 +1,16 @@
+<template>
+</template>
+<script>
+  export default {
+    
+    // VuePouch adds a `pouch` config option to all components.
+    data() {
+      // The simplest usage. queries all documents from the "todos" pouch database and assigns them to the "todos" vue property.
+      return { 
+          todos: {/*empty selector*/}
+      }
+    }
+    
+    
+  }
+</script>

--- a/tests/ExistingTodosDataFunction.vue
+++ b/tests/ExistingTodosDataFunction.vue
@@ -2,8 +2,6 @@
 </template>
 <script>
   export default {
-    
-    // VuePouch adds a `pouch` config option to all components.
     data() {
       // The simplest usage. queries all documents from the "todos" pouch database and assigns them to the "todos" vue property.
       return { 

--- a/tests/emptyDataFunction.vue
+++ b/tests/emptyDataFunction.vue
@@ -2,13 +2,8 @@
 </template>
 <script>
   export default {
-    
-    // VuePouch adds a `pouch` config option to all components.
     data() {
-      // The simplest usage. queries all documents from the "todos" pouch database and assigns them to the "todos" vue property.
-      return { 
-          //fodos: {/*empty selector*/}
-      }
+      return { }
     }
     
     

--- a/tests/emptyDataFunction.vue
+++ b/tests/emptyDataFunction.vue
@@ -1,0 +1,16 @@
+<template>
+</template>
+<script>
+  export default {
+    
+    // VuePouch adds a `pouch` config option to all components.
+    data() {
+      // The simplest usage. queries all documents from the "todos" pouch database and assigns them to the "todos" vue property.
+      return { 
+          //fodos: {/*empty selector*/}
+      }
+    }
+    
+    
+  }
+</script>

--- a/tests/emptyDataObject.vue
+++ b/tests/emptyDataObject.vue
@@ -1,0 +1,11 @@
+<template>
+</template>
+<script>
+  export default {
+    
+    // VuePouch adds a `pouch` config option to all components.
+    data: {}
+    
+    
+  }
+</script>

--- a/tests/emptyDataObject.vue
+++ b/tests/emptyDataObject.vue
@@ -2,8 +2,6 @@
 </template>
 <script>
   export default {
-    
-    // VuePouch adds a `pouch` config option to all components.
     data: {}
     
     

--- a/tests/global-mocks.js
+++ b/tests/global-mocks.js
@@ -1,0 +1,5 @@
+const fetchPolyfill = require('node-fetch')
+global.fetch = fetchPolyfill.fetch
+global.Request = fetchPolyfill.Request
+global.Headers = fetchPolyfill.Headers
+global.Response = fetchPolyfill.Response

--- a/tests/noDataFunctionOrObject.vue
+++ b/tests/noDataFunctionOrObject.vue
@@ -1,0 +1,8 @@
+<template>
+</template>
+<script>
+  export default {
+    
+    
+  }
+</script>

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -1,22 +1,25 @@
-import { exportAllDeclaration } from "@babel/types";
+import PouchDB from 'pouchdb-node';
+import PouchVue from '../src/index'
+import lf from 'pouchdb-find';
+import plf from 'pouchdb-live-find';
+
+// vue-test-utils
+import { createLocalVue, mount } from '@vue/test-utils'
+
+// import test vue single file components
 import emptyDataFunction from './emptyDataFunction.vue'
 import emptyDataObject from './emptyDataObject.vue'
 import noData from './noDataFunctionOrObject.vue'
 import existingData from './ExistingTodosDataFunction.vue'
-import Vue from 'vue'
-import { createLocalVue, mount } from '@vue/test-utils'
-import PouchDB from 'pouchdb-node';
-import PouchVue from '../src/index'
-import 'pouchdb-utils'
-import lf from 'pouchdb-find';
-import plf from 'pouchdb-live-find';
 
 
 describe('Unit Tests for beforeCreate lifecycle hook on Vue components', () => {
-    var testDatum = [{name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
+    var testDatum = [
+      {name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
       {name: 'Test Plugin with Empty Data Object', component: emptyDataObject},
       {name: 'Test Plugin with No Data Function Or Object', component: noData},
-      {name: 'Test Plugin with Existing Data Function', component: existingData}];
+      {name: 'Test Plugin with Existing Data Function', component: existingData}
+    ];
 
     for(var i = 0; i < testDatum.length; i++) {
 
@@ -48,8 +51,6 @@ describe('Unit Tests for beforeCreate lifecycle hook on Vue components', () => {
 
         expect(wrapper.vm.$data.todos).not.toBeUndefined();
         }
-      
-
       test(tryTestName, testFunc);
     }
 

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -1,0 +1,56 @@
+import { exportAllDeclaration } from "@babel/types";
+import emptyDataFunction from './emptyDataFunction.vue'
+import emptyDataObject from './emptyDataObject.vue'
+import noData from './noDataFunctionOrObject.vue'
+import existingData from './ExistingTodosDataFunction.vue'
+import Vue from 'vue'
+import { createLocalVue, mount } from '@vue/test-utils'
+import PouchDB from 'pouchdb-node';
+import PouchVue from '../src/index'
+import 'pouchdb-utils'
+import lf from 'pouchdb-find';
+import plf from 'pouchdb-live-find';
+
+
+describe('Unit Tests for beforeCreate lifecycle hook on Vue components', () => {
+    var testDatum = [{name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
+      {name: 'Test Plugin with Empty Data Object', component: emptyDataObject},
+      {name: 'Test Plugin with No Data Function Or Object', component: noData},
+      {name: 'Test Plugin with Existing Data Function', component: existingData}];
+
+    for(var i = 0; i < testDatum.length; i++) {
+
+
+      let tryTestData = testDatum[i].component;
+      let tryTestName = testDatum[i].name;
+
+      function testFunc () {
+        const localVue = createLocalVue()
+        
+        // add requisite PouchDB plugins
+        PouchDB.plugin(lf);
+        PouchDB.plugin(plf);
+      
+        // add Vue.js plugin
+        localVue.use(PouchVue,{
+          pouch: PouchDB,
+          defaultDB: 'farfromhere', 
+        });
+        
+        const wrapper = mount(tryTestData, {
+          localVue,
+          pouch() {
+            return { 
+              todos: {/*empty selector*/}
+            }
+          }
+        })
+
+        expect(wrapper.vm.$data.todos).not.toBeUndefined();
+        }
+      
+
+      test(tryTestName, testFunc);
+    }
+
+})


### PR DESCRIPTION
This pull request resolves issues #11 and #12. There are also four unit tests included to test the beforeCreate lifecycle hook using Jest. All were successful when I ran the tests.

Issue 11: Is installSelectorReplicationPlugin() still needed when there's the pouchdb-find plugin now?
Issue 12: Reactive Pouch Database Property is null in data() but available on root-level this

Let me know what you think!