### PR TITLE
removed reactivity on $pouch api, some reactivity code changes, bug fix, and new unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:unit": "jest --no-cache"
   },
   "jest": {
+    "verbose": true,
     "setupFiles": [
       "<rootDir>/tests/global-mocks.js"
     ],
@@ -51,6 +52,7 @@
   ],
   "homepage": "https://github.com/MDSLKTR/pouch-vue",
   "dependencies": {
+    "pouchdb-authentication": "^1.1.3",
     "pouchdb-live-find": "^0.4.0",
     "pouchdb-utils": "^6.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   ],
   "homepage": "https://github.com/MDSLKTR/pouch-vue",
   "dependencies": {
-    "pouchdb-authentication": "^1.1.3",
     "pouchdb-live-find": "^0.4.0",
     "pouchdb-utils": "^6.4.3"
   },
@@ -68,6 +67,7 @@
     "jest": "^24.7.1",
     "node-fetch": "^2.3.0",
     "pouchdb-find": "^7.0.0",
+    "pouchdb-authentication": "^1.1.3",
     "pouchdb-node": "^7.0.0",
     "rollup": "^1.7.4",
     "rollup-plugin-babel": "^4.3.2",

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -12,94 +12,183 @@ import emptyDataObject from './emptyDataObject.vue'
 import noData from './noDataFunctionOrObject.vue'
 import existingData from './ExistingTodosDataFunction.vue'
 
-
-describe('Unit Tests that todos is defined on Vue components', () => {
+describe('Pouch options are returned by function', () => {
+  describe('Unit Tests that todos is defined on Vue components', () => {
     var testDatum = [
-      {name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
-      {name: 'Test Plugin with Empty Data Object', component: emptyDataObject},
-      {name: 'Test Plugin with No Data Function Or Object', component: noData},
-      {name: 'Test Plugin with Existing Data Function', component: existingData}
+      { name: 'Test Plugin with Empty Data Function', component: emptyDataFunction },
+      { name: 'Test Plugin with Empty Data Object', component: emptyDataObject },
+      { name: 'Test Plugin with No Data Function Or Object', component: noData },
+      { name: 'Test Plugin with Existing Data Function', component: existingData }
     ];
 
-    for(var i = 0; i < testDatum.length; i++) {
+    for (var i = 0; i < testDatum.length; i++) {
 
 
       let tryTestData = testDatum[i].component;
       let tryTestName = testDatum[i].name;
 
-      function testFunc () {
+      function testFunc() {
         const localVue = createLocalVue()
-        
+
         // add requisite PouchDB plugins
         PouchDB.plugin(lf);
         PouchDB.plugin(plf);
-      
+
         // add Vue.js plugin
-        localVue.use(PouchVue,{
+        localVue.use(PouchVue, {
           pouch: PouchDB,
-          defaultDB: 'farfromhere', 
+          defaultDB: 'farfromhere',
         });
-        
+
 
         const wrapper = mount(tryTestData, {
           localVue,
           pouch() {
-            return { 
-              todos: {/*empty selector*/}
+            return {
+              todos: {/*empty selector*/ }
             }
           }
         })
 
         expect(wrapper.vm.$data.todos).not.toBeUndefined();
-        }
+      }
       test(tryTestName, testFunc);
     }
+  })
+
+  describe('Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)', () => {
+    var testDatum = [
+      { name: 'Test Plugin with Empty Data Function', component: emptyDataFunction },
+      { name: 'Test Plugin with Empty Data Object', component: emptyDataObject },
+      { name: 'Test Plugin with No Data Function Or Object', component: noData },
+      { name: 'Test Plugin with Existing Data Function', component: existingData }
+    ];
+
+    for (var i = 0; i < testDatum.length; i++) {
+
+
+      let tryTestData = testDatum[i].component;
+      let tryTestName = testDatum[i].name;
+
+      function testFunc() {
+        const localVue = createLocalVue()
+
+        // add requisite PouchDB plugins
+        PouchDB.plugin(lf);
+        PouchDB.plugin(plf);
+
+        // add Vue.js plugin
+        localVue.use(PouchVue, {
+          pouch: PouchDB,
+          defaultDB: 'farfromhere',
+        });
+
+
+        const wrapper = mount(tryTestData, {
+          localVue,
+          pouch() {
+            return {
+              todos: {/*empty selector*/ }
+            }
+          }
+        })
+
+        wrapper.vm.todos = ['north', 'east', 'south', 'west'];
+
+        expect(wrapper.vm.$data.todos).toBe(wrapper.vm.todos);
+
+      }
+      test(tryTestName, testFunc);
+    }
+
+  })
 })
 
-describe('Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)', () => {
-  var testDatum = [
-    {name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
-    {name: 'Test Plugin with Empty Data Object', component: emptyDataObject},
-    {name: 'Test Plugin with No Data Function Or Object', component: noData},
-    {name: 'Test Plugin with Existing Data Function', component: existingData}
-  ];
+describe('Pouch options are objects', () => {
+  describe('Unit Tests that todos is defined on Vue components', () => {
+    var testDatum = [
+      { name: 'Test Plugin with Empty Data Function', component: emptyDataFunction },
+      { name: 'Test Plugin with Empty Data Object', component: emptyDataObject },
+      { name: 'Test Plugin with No Data Function Or Object', component: noData },
+      { name: 'Test Plugin with Existing Data Function', component: existingData }
+    ];
 
-  for(var i = 0; i < testDatum.length; i++) {
+    for (var i = 0; i < testDatum.length; i++) {
 
 
-    let tryTestData = testDatum[i].component;
-    let tryTestName = testDatum[i].name;
+      let tryTestData = testDatum[i].component;
+      let tryTestName = testDatum[i].name;
 
-    function testFunc () {
-      const localVue = createLocalVue()
-      
-      // add requisite PouchDB plugins
-      PouchDB.plugin(lf);
-      PouchDB.plugin(plf);
-    
-      // add Vue.js plugin
-      localVue.use(PouchVue,{
-        pouch: PouchDB,
-        defaultDB: 'farfromhere', 
-      });
-      
+      function testFunc() {
+        const localVue = createLocalVue()
 
-      const wrapper = mount(tryTestData, {
-        localVue,
-        pouch() {
-          return { 
-            todos: {/*empty selector*/}
+        // add requisite PouchDB plugins
+        PouchDB.plugin(lf);
+        PouchDB.plugin(plf);
+
+        // add Vue.js plugin
+        localVue.use(PouchVue, {
+          pouch: PouchDB,
+          defaultDB: 'farfromhere',
+        });
+
+
+        const wrapper = mount(tryTestData, {
+          localVue,
+          pouch: {
+              todos: {/*empty selector*/ }
           }
+        })
+
+        expect(wrapper.vm.$data.todos).not.toBeUndefined();
+      }
+      test(tryTestName, testFunc);
+    }
+  })
+
+  describe('Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)', () => {
+    var testDatum = [
+      { name: 'Test Plugin with Empty Data Function', component: emptyDataFunction },
+      { name: 'Test Plugin with Empty Data Object', component: emptyDataObject },
+      { name: 'Test Plugin with No Data Function Or Object', component: noData },
+      { name: 'Test Plugin with Existing Data Function', component: existingData }
+    ];
+
+    for (var i = 0; i < testDatum.length; i++) {
+
+
+      let tryTestData = testDatum[i].component;
+      let tryTestName = testDatum[i].name;
+
+      function testFunc() {
+        const localVue = createLocalVue()
+
+        // add requisite PouchDB plugins
+        PouchDB.plugin(lf);
+        PouchDB.plugin(plf);
+
+        // add Vue.js plugin
+        localVue.use(PouchVue, {
+          pouch: PouchDB,
+          defaultDB: 'farfromhere',
+        });
+
+
+        const wrapper = mount(tryTestData, {
+          localVue,
+          pouch: {
+            todos: {/*empty selector*/ }
         }
       })
 
-      wrapper.vm.todos = ['north', 'east', 'south', 'west'];
+        wrapper.vm.todos = ['north', 'east', 'south', 'west'];
 
-      expect(wrapper.vm.$data.todos).toBe(wrapper.vm.todos);
+        expect(wrapper.vm.$data.todos).toBe(wrapper.vm.todos);
 
       }
-    test(tryTestName, testFunc);
-  }
+      test(tryTestName, testFunc);
+    }
 
+  })
 })
 

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -54,8 +54,8 @@ describe('Unit Tests that todos is defined on Vue components', () => {
         }
       test(tryTestName, testFunc);
     }
-
 })
+
 describe('Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)', () => {
   var testDatum = [
     {name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
@@ -95,9 +95,11 @@ describe('Unit Tests to see that the todos property on the data root level is co
 
       wrapper.vm.todos = ['north', 'east', 'south', 'west'];
 
-      expect(wrapper.vm.$data.todos).toHaveLength(4);
+      expect(wrapper.vm.$data.todos).toBe(wrapper.vm.todos);
+
       }
     test(tryTestName, testFunc);
   }
 
 })
+

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -13,7 +13,7 @@ import noData from './noDataFunctionOrObject.vue'
 import existingData from './ExistingTodosDataFunction.vue'
 
 
-describe('Unit Tests for beforeCreate lifecycle hook on Vue components', () => {
+describe('Unit Tests that todos is defined on Vue components', () => {
     var testDatum = [
       {name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
       {name: 'Test Plugin with Empty Data Object', component: emptyDataObject},
@@ -40,6 +40,7 @@ describe('Unit Tests for beforeCreate lifecycle hook on Vue components', () => {
           defaultDB: 'farfromhere', 
         });
         
+
         const wrapper = mount(tryTestData, {
           localVue,
           pouch() {
@@ -53,5 +54,50 @@ describe('Unit Tests for beforeCreate lifecycle hook on Vue components', () => {
         }
       test(tryTestName, testFunc);
     }
+
+})
+describe('Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)', () => {
+  var testDatum = [
+    {name: 'Test Plugin with Empty Data Function', component: emptyDataFunction},
+    {name: 'Test Plugin with Empty Data Object', component: emptyDataObject},
+    {name: 'Test Plugin with No Data Function Or Object', component: noData},
+    {name: 'Test Plugin with Existing Data Function', component: existingData}
+  ];
+
+  for(var i = 0; i < testDatum.length; i++) {
+
+
+    let tryTestData = testDatum[i].component;
+    let tryTestName = testDatum[i].name;
+
+    function testFunc () {
+      const localVue = createLocalVue()
+      
+      // add requisite PouchDB plugins
+      PouchDB.plugin(lf);
+      PouchDB.plugin(plf);
+    
+      // add Vue.js plugin
+      localVue.use(PouchVue,{
+        pouch: PouchDB,
+        defaultDB: 'farfromhere', 
+      });
+      
+
+      const wrapper = mount(tryTestData, {
+        localVue,
+        pouch() {
+          return { 
+            todos: {/*empty selector*/}
+          }
+        }
+      })
+
+      wrapper.vm.todos = ['north', 'east', 'south', 'west'];
+
+      expect(wrapper.vm.$data.todos).toHaveLength(4);
+      }
+    test(tryTestName, testFunc);
+  }
 
 })


### PR DESCRIPTION
I think the reason the $pouch api was reactive previously was because the original buhrmi/vue-pouch repo actually had a few properties in the api along with the methods (https://github.com/buhrmi/vue-pouch/blob/aab3e6e99e727a1840a82cd8a099a321a8b912c2/index.js#L148-L152) that needed to be reactive. Those properties from the buhrmi/vue-pouch repo are now gone:

```
        session: {},
        errors: {},
        loading: {},
        authError: null,
        gotAuth: false

```
So I removed reactivity on the $pouch api. 

I have created new unit tests that test for reactivity of the pouch databases inthe database object. The previous unit tests only tested whether the pouch database property on the data object was defined or not:

```
 PASS  tests/testData.spec.js
  Unit Tests that todos is defined on Vue components
    √ Test Plugin with Empty Data Function (34ms)
    √ Test Plugin with Empty Data Object (8ms)
    √ Test Plugin with No Data Function Or Object (1ms)
    √ Test Plugin with Existing Data Function (2ms)
  Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)
    √ Test Plugin with Empty Data Function (2ms)
    √ Test Plugin with Empty Data Object (2ms)
    √ Test Plugin with No Data Function Or Object (1ms)
    √ Test Plugin with Existing Data Function (1ms)

```
In manual tests liveFinds still work (they use a watcher on the selectors) and sync still works.

I fixed a bug found with the new unit tests in the new beforeCreate hook: pouchOptions need to be converted to functions if not already

Let me know what you think. Thanks!
