### PR TITLE
Add custom vue events, clean up watcher code, add unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,11 @@ ___
 **For example:**
 ```
     $pouch.sync('complaints', 'https:/42.233.1.44/complaints', {
-      filter:'_selector',
-      selector: {
-        type: 'complaint',
-        assignee: this.session.name
-      }
-    });
+        selector: {
+            type: 'complaint',
+            assignee: this.session.name
+        }
+      });
 
 ```
 * `$pouch.push(localDatabase, remoteDatabase, options)`: Like https://pouchdb.com/api.html#replication - replicate-to. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.

--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,9 @@ import { isRemote } from 'pouchdb-utils';
             let oldDataFunc = this.$options.data;      
 
             // the data function is explicitly passed a vm object in 
-            // we're calling it veem here to differentiate with vm which is used often in this plugin
-            this.$options.data= function(veem) {
+            this.$options.data= function(vm) {
                 // get the Vue instance's data object from the constructor
-                var plainObject = oldDataFunc.call(veem, veem);
+                var plainObject = oldDataFunc.call(vm, vm);
 
                 // map the pouch databases to an object in the Vue instance's data
                 Object.keys(pouchOptions).map(function (key) {
@@ -765,9 +764,8 @@ import { isRemote } from 'pouchdb-utils';
                         if (!db) {
                             vm.$emit('pouchdb-livefeed-error', {
                                 db: key,
-                                config: config,
                                 error: 'Null or undefined database'
-                            });                            
+                            });
                             return;
                         }
                         if (vm._liveFeeds[key]) {
@@ -794,7 +792,7 @@ import { isRemote } from 'pouchdb-utils';
                                     db: key,
                                     name: db.name
                                 });
-    
+
                             })
                             .on('ready', () => {
                                 vm.$data[key] = aggregateCache;
@@ -804,28 +802,25 @@ import { isRemote } from 'pouchdb-utils';
                                     name: db.name
                                 });
                             })
-                            .on('cancelled', function() {
+                            .on('cancelled', function () {
                                 vm.$emit('pouchdb-livefeed-cancel', {
                                     db: key,
-                                    name: db.name,                                                                        
                                     name: db.name
                                 });
-                              })
-                              .on('error', function(err) {
+                            })
+                            .on('error', function (err) {
                                 vm.$emit('pouchdb-livefeed-error', {
                                     db: key,
-                                    name: db.name,                                    
-                                    errorobject: err,
-                                    error: 'Null or undefined selector'
+                                    name: db.name,
+                                    error: err,
                                 });
-                              })
-                              .then( () => {
+                            })
+                            .then(() => {
                                 vm.$emit('pouchdb-livefeed-created', {
-                                db: key,
-                                name: db.name,                                                                    
-                                config: config,
+                                    db: key,
+                                    name: db.name,
                                 })
-                            });                            
+                            });
                     },
                     {
                         immediate: true,

--- a/src/index.js
+++ b/src/index.js
@@ -730,13 +730,7 @@ import { isRemote } from 'pouchdb-utils';
 
                             return;
                         }
-                        else {
-                            vm.$emit('pouchdb-livefeed-created', {
-                                db: key,
-                                config: config,
-                            });
 
-                        }
 
                         let selector, sort, skip, limit, first;
 
@@ -769,6 +763,11 @@ import { isRemote } from 'pouchdb-utils';
                             db = databases[databaseParam];
                         }
                         if (!db) {
+                            vm.$emit('pouchdb-livefeed-error', {
+                                db: key,
+                                config: config,
+                                error: 'Null or undefined database'
+                            });                            
                             return;
                         }
                         if (vm._liveFeeds[key]) {
@@ -804,7 +803,29 @@ import { isRemote } from 'pouchdb-utils';
                                     db: key,
                                     name: db.name
                                 });
-                            });
+                            })
+                            .on('cancelled', function() {
+                                vm.$emit('pouchdb-livefeed-cancel', {
+                                    db: key,
+                                    name: db.name,                                                                        
+                                    name: db.name
+                                });
+                              })
+                              .on('error', function(err) {
+                                vm.$emit('pouchdb-livefeed-error', {
+                                    db: key,
+                                    name: db.name,                                    
+                                    errorobject: err,
+                                    error: 'Null or undefined selector'
+                                });
+                              })
+                              .then( () => {
+                                vm.$emit('pouchdb-livefeed-created', {
+                                db: key,
+                                name: db.name,                                                                    
+                                config: config,
+                                })
+                            });                            
                     },
                     {
                         immediate: true,

--- a/tests/TodosDataFunctionWithSelector.vue
+++ b/tests/TodosDataFunctionWithSelector.vue
@@ -1,0 +1,16 @@
+<template>
+</template>
+<script>
+  export default {
+    data() {
+      // The simplest usage. queries all documents from the "todos" pouch database and assigns them to the "todos" vue property.
+      return { 
+          todos: null,//{/*empty selector*/},
+          age: 45,
+          maxAge: 40
+      }
+    }
+    
+    
+  }
+</script>

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -11,6 +11,7 @@ import emptyDataFunction from './emptyDataFunction.vue'
 import emptyDataObject from './emptyDataObject.vue'
 import noData from './noDataFunctionOrObject.vue'
 import existingData from './ExistingTodosDataFunction.vue'
+import todosDataWithSelector from './TodosDataFunctionWithSelector.vue'
 
 describe('Pouch options are returned by function', () => {
   describe('Unit Tests that todos is defined on Vue components', () => {
@@ -136,7 +137,7 @@ describe('Pouch options are objects', () => {
         const wrapper = mount(tryTestData, {
           localVue,
           pouch: {
-              todos: {/*empty selector*/ }
+            todos: {/*empty selector*/ }
           }
         })
 
@@ -178,8 +179,8 @@ describe('Pouch options are objects', () => {
           localVue,
           pouch: {
             todos: {/*empty selector*/ }
-        }
-      })
+          }
+        })
 
         wrapper.vm.todos = ['north', 'east', 'south', 'west'];
 
@@ -191,4 +192,48 @@ describe('Pouch options are objects', () => {
 
   })
 })
+describe('Set selector to null', () => {
+    var testDatum = [
+      { name: 'Test Plugin with Reactive Selector that can return null', component: todosDataWithSelector },
+    ];
 
+    for (var i = 0; i < testDatum.length; i++) {
+
+
+      let tryTestData = testDatum[i].component;
+      let tryTestName = testDatum[i].name;
+
+      // selector will return null if the age is less than the max age
+      // purely to get a reactive selector that will return null occasionally and
+      // trip up the watcher on the pouch database config options
+      let selector = function () { return (this.age < this.maxAge) ? null : {} }
+
+      function testFunc() {
+        const localVue = createLocalVue()
+
+        // add requisite PouchDB plugins
+        PouchDB.plugin(lf);
+        PouchDB.plugin(plf);
+
+        // add Vue.js plugin
+        localVue.use(PouchVue, {
+          pouch: PouchDB,
+          defaultDB: 'farfromhere',
+        });
+
+
+        const wrapper = mount(tryTestData, {
+          localVue,
+          pouch: {
+            todos: selector
+          }
+        })
+
+        wrapper.vm.todos = ['north', 'east', 'south', 'west'];
+
+        wrapper.vm.maxAge = 50;
+        expect(wrapper.emitted('pouchdb-livefeed-selector-error')).toHaveLength(1);
+      }
+      test(tryTestName, testFunc);
+    }
+})

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -232,7 +232,7 @@ describe('Set selector to null', () => {
         wrapper.vm.todos = ['north', 'east', 'south', 'west'];
 
         wrapper.vm.maxAge = 50;
-        expect(wrapper.emitted('pouchdb-livefeed-selector-error')).toHaveLength(1);
+        expect(wrapper.emitted('pouchdb-livefeed-error')).toHaveLength(1);
       }
       test(tryTestName, testFunc);
     }


### PR DESCRIPTION
Another PR! Thanks for approving the last one. 

In this PR there's a minor fix to the watcher code when pouch config options are null. I think the expected behavior is that if the pouch config options are null for some reason then don't do anything and simply return, no need to check if the key exists on the vue instance since all this is handled in the beforeCreate lifecycle hook. I've added a custom Vue event to emit 'pouchdb-livefeed-error' now and have created a unit test to make sure this behavior occurs.

Added a few more custom vue events to attach to events emitted by the liveFeed object.

Result of unit tests:

 ```
PASS  tests/testData.spec.js
  Pouch options are returned by function
    Unit Tests that todos is defined on Vue components
      √ Test Plugin with Empty Data Function (16ms)
      √ Test Plugin with Empty Data Object (15ms)
      √ Test Plugin with No Data Function Or Object
      √ Test Plugin with Existing Data Function
    Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)
      √ Test Plugin with Empty Data Function
      √ Test Plugin with Empty Data Object
      √ Test Plugin with No Data Function Or Object
      √ Test Plugin with Existing Data Function
  Pouch options are objects
    Unit Tests that todos is defined on Vue components
      √ Test Plugin with Empty Data Function
      √ Test Plugin with Empty Data Object
      √ Test Plugin with No Data Function Or Object (16ms)
      √ Test Plugin with Existing Data Function
    Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)
      √ Test Plugin with Empty Data Function
      √ Test Plugin with Empty Data Object
      √ Test Plugin with No Data Function Or Object
      √ Test Plugin with Existing Data Function
  Set selector to null
    √ Test Plugin with Reactive Selector that can return null
```

Let me know what you think. Thanks!