### PR TITLE
Use type declaration file generated from ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ main.ts
 import { Component, Vue } from 'vue-property-decorator';
 import PouchDB from 'pouchdb-browser';
 import lf from 'pouchdb-find';
-// @ts-ignore
 import plf from 'pouchdb-live-find';
 import auth from 'pouchdb-authentication';
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,68 +1,75 @@
-declare module "pouch-vue" {
-  import _Vue, { PluginObject, ComponentOptions } from 'vue'
-  import PouchDB from 'pouchdb-core';
-  
-  interface PublicPouchVueMethods {
-    connect(username: string, password: string, db?: any): any;
-    createUser(username: string, password: string, db?: any): any;
-    putUser (username: string, metadata?: {}, db?: any): any;
-    deleteUser (username: string, db?: any): any;
-    changePassword (username: string, password: string, db?: any): any;
-    changeUsername (oldUsername: string, newUsername: string, db?: any): any;
-    signUpAdmin (adminUsername: string, adminPassword: string, db?: any): any;
-    deleteAdmin (adminUsername: string, db?: any): any;
-    disconnect(db?: any): any;
-    destroy(db?: any): any;
-    defaults(options?: {}): any;
-    close(db?: string): any;
-    getSession(db?: any): any;
-    sync(localDB: string, remoteDB: string, options?: {}): any;
-    push(localDB: string, remoteDB: string, options?: {}): any;
-    pull(localDB: string, remoteDB: string, options?: {}): any;
-    changes(db: string, options?: {}): any;
-    get(db: string, object: any, options?: {}): any;
-    put(db: string, object: any, options?: {}): any;
-    post(db: string, object: any, options?: {}): any;
-    remove(db: string, object: any, options?: {}): any;
-    query(db: string, fun: any, options?: {}): any;
-    find(db: string, options?: {}): any;
-    createIndex(db: string, index?: {}): any;
-    allDocs(db: string, options?: {}): any;
-    bulkDocs(db: string, docs: any, options?: {}): any;
-    compact(db: string, options?: {}): any;
-    viewCleanup(db: string): any;
-    info(db: string): any;
-    putAttachment(db: string, docId: any, rev: any, attachment: any): any;
-    getAttachment(db: string, docId: any, attachmentId: any): any;
-    deleteAttachment(db: string, docId: any, attachmentId: any, docRev: any): any;
-  }
-
-  // extend definition for plugin function: https://github.com/vuejs/vue/blob/dev/types/plugin.d.ts
-  // nice intro: https://www.mistergoodcat.com/post/vuejs-plugins-with-typescript
-
-  interface PouchVueOptions {
+/// <reference types="pouchdb-live-find" />
+/// <reference types="pouchdb-find" />
+/// <reference types="pouchdb-core" />
+/// <reference types="pouchdb-authentication" />
+/// <reference types="pouchdb-mapreduce" />
+/// <reference types="pouchdb-replication" />
+/// <reference types="node" />
+import _Vue, { PluginObject } from 'vue';
+declare type PouchDatabases = Record<string, PouchDB.Database>;
+interface PouchVueOptions {
     pouch: PouchDB.Static;
     defaultDB: string;
     debug: string;
     optionsDB: any;
-  }
-  
-  export var {install, mixin} : PluginObject<PouchVueOptions>;
-
-  // https://vuejs.org/v2/guide/typescript.html#Augmenting-Types-for-Use-with-Plugins
-
-  // for the main Vue instance
-  module 'vue/types/vue' {
-    // Declare augmentation for Vue
-    interface Vue {
-      $pouch: PublicPouchVueMethods;
-    }
-  }
-
-  // for the components
-  module 'vue/types/options' {
-    interface ComponentOptions<V extends _Vue> {
-      pouch?: any     // this is where the database will be reactive
-    }
-  }
 }
+interface PouchAPI {
+    version: string;
+    connect(username: string, password: string, db?: PouchDB.Database): Promise<any>;
+    createUser(username: string, password: string, db?: PouchDB.Database): Promise<any>;
+    putUser(username: string, metadata?: {}, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
+    deleteUser(username: string, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
+    changePassword(username: string, password: string, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
+    changeUsername(oldUsername: string, newUsername: string, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
+    signUpAdmin(adminUsername: string, adminPassword: string, db?: PouchDB.Database): Promise<string | {}>;
+    deleteAdmin(adminUsername: string, db?: PouchDB.Database): Promise<string | {}>;
+    disconnect(db?: PouchDB.Database): void;
+    destroy(db?: string): void;
+    defaults(options?: PouchDB.Configuration.DatabaseConfiguration): void;
+    close(db?: string): Promise<void>;
+    getSession(db?: PouchDB.Database): Promise<{}>;
+    sync(localDB: string, remoteDB: string, options?: {}): PouchDB.Replication.Sync<{}>;
+    push(localDB: string, remoteDB: string, options?: {}): PouchDB.Replication.Replication<{}>;
+    pull(localDB: string, remoteDB: string, options?: {}): PouchDB.Replication.Replication<{}>;
+    changes(db: string, options?: {}): PouchDB.Core.Changes<{}>;
+    get(db: string, object: any, options?: PouchDB.Core.GetOptions): Promise<any>;
+    put(db: string, object: any, options?: PouchDB.Core.PutOptions): Promise<PouchDB.Core.Response>;
+    post(db: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
+    remove(db: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
+    query(db: string, fun: any, options?: PouchDB.Query.Options<{}, {}>): Promise<PouchDB.Query.Response<{}>>;
+    find(db: string, options?: PouchDB.Find.FindRequest<{}>): Promise<PouchDB.Find.FindResponse<{}>>;
+    createIndex(db: string, index?: PouchDB.Find.CreateIndexOptions): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
+    allDocs(db: string, options?: PouchDB.Core.AllDocsWithKeyOptions | PouchDB.Core.AllDocsWithKeysOptions | PouchDB.Core.AllDocsWithinRangeOptions | PouchDB.Core.AllDocsOptions): Promise<PouchDB.Core.AllDocsResponse<{}>>;
+    bulkDocs(db: string, docs: PouchDB.Core.PutDocument<{}>[], options?: PouchDB.Core.BulkDocsOptions): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
+    compact(db: string, options?: PouchDB.Core.CompactOptions): Promise<PouchDB.Core.Response>;
+    viewCleanup(db: string): Promise<PouchDB.Core.BasicResponse>;
+    info(db: string): Promise<PouchDB.Core.DatabaseInfo>;
+    putAttachment(db: string, docId: PouchDB.Core.DocumentId, rev: string, attachment: {
+        id: string;
+        data: PouchDB.Core.AttachmentData;
+        type: string;
+    }): Promise<PouchDB.Core.Response>;
+    getAttachment(db: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId): Promise<Blob | Buffer>;
+    deleteAttachment(db: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId, docRev: PouchDB.Core.RevisionId): Promise<PouchDB.Core.RemoveAttachmentResponse>;
+}
+declare module 'vue/types/vue' {
+    interface VueConstructor {
+        util: {
+            mergeOptions(parent: Object, child: Object, vm?: any): Object;
+        };
+        options: any;
+    }
+    interface Vue {
+        $pouch: PouchAPI;
+        $databases: PouchDatabases;
+        _liveFeeds: Record<string, PouchDB.LiveFind.LiveFeed>;
+        options: any;
+    }
+}
+declare module 'vue/types/options' {
+    interface ComponentOptions<V extends _Vue> {
+        pouch?: any;
+    }
+}
+declare let api: PluginObject<PouchVueOptions>;
+export default api;


### PR DESCRIPTION
The TypeScript version of this Vue.js plugin generates a better type declaration file and this is it.

I figure this can be the last PR and then a release 0.1.38 can be pushed to npm.

Following that, I will do a PR from the MDSLKTR/pouch-vue#typescript branch that can be release 0.2.0. This branch uses typings for pouchdb-live-find and generates its own type declaration file (.d.ts). The Vue.js plugin is now written in TypeScript and rollup transpiles it into a js module. I'm actually testing with release 0.2.0 now and it's working well, though I'm sure it could be improved further.