### PR TITLE
Consistency in API for issue #18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pouch-vue",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "PouchDB bindings for Vue.js",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -590,35 +590,35 @@ import { isRemote } from 'pouchdb-utils';
                     return changes;
                 },
 
-                get(db=defaultDB, object, options = {}) {
+                get(object, db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].get(object, options);
                 },
 
-                put(db=defaultDB, object, options = {}) {
+                put(object, db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].put(object, options);
                 },
 
-                post(db=defaultDB, object, options = {}) {
+                post(object, db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].post(object, options);
                 },
 
-                remove(db=defaultDB, object, options = {}) {
+                remove(object, db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].remove(object, options);
                 },
 
-                query(db=defaultDB, fun, options = {}) {
+                query(fun, db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -655,7 +655,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].allDocs(_options);
                 },
 
-                bulkDocs(db=defaultDB, docs, options = {}) {
+                bulkDocs(docs, db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -687,7 +687,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].info();
                 },
 
-                putAttachment(db=defaultDB, docId, rev, attachment) {
+                putAttachment(docId, rev, attachment, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -701,7 +701,7 @@ import { isRemote } from 'pouchdb-utils';
                     );
                 },
 
-                getAttachment(db=defaultDB, docId, attachmentId) {
+                getAttachment(docId, attachmentId, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -709,7 +709,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].getAttachment(docId, attachmentId);
                 },
 
-                deleteAttachment(db=defaultDB, docId, attachmentId, docRev) {
+                deleteAttachment(docId, attachmentId, docRev, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }

--- a/src/index.js
+++ b/src/index.js
@@ -147,12 +147,16 @@ import { isRemote } from 'pouchdb-utils';
 
             let $pouch = {
                 version: '__VERSION__',
-                connect(username, password, db = databases[defaultDB]) {
+                connect(username, password, db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+
                     return new Promise(resolve => {
                         defaultUsername = username;
                         defaultPassword = password;
 
-                        if (!isRemote(db)) {
+                        if (!isRemote(databases[db])) {
                             resolve({
                                 message: 'database is not remote',
                                 error: 'bad request',
@@ -161,13 +165,16 @@ import { isRemote } from 'pouchdb-utils';
                             return;
                         }
 
-                        login(db).then(res => {
+                        login(databases[db]).then(res => {
                             resolve(res);
                         });
                     });
                 },
-                createUser(username, password, db = databases[defaultDB]) {
-                    return db
+                createUser(username, password, db = defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    return databases[db]
                         .signUp(username, password)
                         .then(() => {
                             return vm.$pouch.connect(username, password, db);
@@ -178,8 +185,11 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
                 },
-                putUser(username, metadata = {}, db = databases[ defaultDB ]) {
-                    return db
+                putUser(username, metadata = {}, db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    return databases[db]
                         .putUser(username, {
                             metadata,
                         })
@@ -189,8 +199,11 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
                 },
-                deleteUser(username, db = databases[ defaultDB ]) {
-                    return db
+                deleteUser(username, db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    return databases[db]
                         .deleteUser(username)
                         .catch(error => {
                             return new Promise(resolve => {
@@ -198,8 +211,11 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
                 },
-                changePassword(username, password, db = databases[ defaultDB ]) {
-                    return db
+                changePassword(username, password, db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    return databases[db]
                         .changePassword(username, password)
                         .catch(error => {
                             return new Promise(resolve => {
@@ -207,8 +223,11 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
                 },
-                changeUsername(oldUsername, newUsername, db = databases[ defaultDB ]) {
-                    return db
+                changeUsername(oldUsername, newUsername, db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    return databases[db]
                         .changeUsername(oldUsername, newUsername)
                         .catch(error => {
                             return new Promise(resolve => {
@@ -216,8 +235,11 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
                 },
-                signUpAdmin(adminUsername, adminPassword, db = databases[ defaultDB ]) {
-                    return db
+                signUpAdmin(adminUsername, adminPassword, db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    return databases[db]
                         .signUpAdmin(adminUsername, adminPassword)
                         .catch(error => {
                             return new Promise(resolve => {
@@ -225,8 +247,11 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
                 },
-                deleteAdmin(adminUsername, db = databases[ defaultDB ]) {
-                    return db
+                deleteAdmin(adminUsername, db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    return databases[db]
                         .deleteAdmin(adminUsername)
                         .catch(error => {
                             return new Promise(resolve => {
@@ -234,12 +259,15 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
                 },
-                disconnect(db = databases[defaultDB]) {
+                disconnect(db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
                     return new Promise(resolve => {
                         defaultUsername = null;
                         defaultPassword = null;
 
-                        if (!isRemote(db)) {
+                        if (!isRemote(databases[db])) {
                             resolve({
                                 message: 'database is not remote',
                                 error: 'bad request',
@@ -248,7 +276,7 @@ import { isRemote } from 'pouchdb-utils';
                             return;
                         }
 
-                        db
+                        databases[db]
                             .logOut()
                             .then(res => {
                                 resolve({
@@ -263,7 +291,7 @@ import { isRemote } from 'pouchdb-utils';
                     });
                 },
 
-                destroy(db) {
+                destroy(db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -279,7 +307,7 @@ import { isRemote } from 'pouchdb-utils';
                     pouch.defaults(options);
                 },
 
-                close(db) {
+                close(db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -291,8 +319,11 @@ import { isRemote } from 'pouchdb-utils';
                     });
                 },
 
-                getSession(db = databases[defaultDB]) {
-                    if (!isRemote(db)) {
+                getSession(db=defaultDB) {
+                    if (!databases[db]) {
+                        makeInstance(db);
+                    }
+                    if (!isRemote(databases[db])) {
                         return new Promise(resolve => {
                             resolve({
                                 message: 'database is not remote',
@@ -304,7 +335,7 @@ import { isRemote } from 'pouchdb-utils';
                     return fetchSession();
                 },
 
-                sync(localDB, remoteDB, options = {}) {
+                sync(localDB, remoteDB=defaultDB, options = {}) {
                     if (!databases[localDB]) {
                         makeInstance(localDB);
                     }
@@ -384,7 +415,7 @@ import { isRemote } from 'pouchdb-utils';
 
                     return sync;
                 },
-                push(localDB, remoteDB, options = {}) {
+                push(localDB, remoteDB=defaultDB, options = {}) {
                     if (!databases[localDB]) {
                         makeInstance(localDB);
                     }
@@ -448,7 +479,7 @@ import { isRemote } from 'pouchdb-utils';
                     return rep;
                 },
 
-                pull(localDB, remoteDB, options = {}) {
+                pull(localDB, remoteDB=defaultDB, options = {}) {
                     if (!databases[localDB]) {
                         makeInstance(localDB);
                     }
@@ -512,7 +543,7 @@ import { isRemote } from 'pouchdb-utils';
                     return rep;
                 },
 
-                changes(db, options = {}) {
+                changes(db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -559,42 +590,42 @@ import { isRemote } from 'pouchdb-utils';
                     return changes;
                 },
 
-                get(db, object, options = {}) {
+                get(db=defaultDB, object, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].get(object, options);
                 },
 
-                put(db, object, options = {}) {
+                put(db=defaultDB, object, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].put(object, options);
                 },
 
-                post(db, object, options = {}) {
+                post(db=defaultDB, object, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].post(object, options);
                 },
 
-                remove(db, object, options = {}) {
+                remove(db=defaultDB, object, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].remove(object, options);
                 },
 
-                query(db, fun, options = {}) {
+                query(db=defaultDB, fun, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].query(fun, options);
                 },
 
-                find(db, options = {}) {
+                find(db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -602,7 +633,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].find(options);
                 },
 
-                createIndex(db, index = {}) {
+                createIndex(db=defaultDB, index = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -610,7 +641,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].createIndex(index);
                 },
 
-                allDocs(db, options = {}) {
+                allDocs(db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -624,7 +655,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].allDocs(_options);
                 },
 
-                bulkDocs(db, docs, options = {}) {
+                bulkDocs(db=defaultDB, docs, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -632,7 +663,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].bulkDocs(docs, options);
                 },
 
-                compact(db, options = {}) {
+                compact(db=defaultDB, options = {}) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -640,7 +671,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].compact(options);
                 },
 
-                viewCleanup(db) {
+                viewCleanup(db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -648,7 +679,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].viewCleanup();
                 },
 
-                info(db) {
+                info(db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -656,7 +687,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].info();
                 },
 
-                putAttachment(db, docId, rev, attachment) {
+                putAttachment(db=defaultDB, docId, rev, attachment) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -670,7 +701,7 @@ import { isRemote } from 'pouchdb-utils';
                     );
                 },
 
-                getAttachment(db, docId, attachmentId) {
+                getAttachment(db=defaultDB, docId, attachmentId) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -678,7 +709,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].getAttachment(docId, attachmentId);
                 },
 
-                deleteAttachment(db, docId, attachmentId, docRev) {
+                deleteAttachment(db=defaultDB, docId, attachmentId, docRev) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,25 +32,25 @@ interface PouchAPI {
     push(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Replication<{}>;
     pull(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Replication<{}>;
     changes(db?: string, options?: {}): PouchDB.Core.Changes<{}>;
-    get(db?: string, object: any, options?: PouchDB.Core.GetOptions): Promise<any>;
-    put(db?: string, object: any, options?: PouchDB.Core.PutOptions): Promise<PouchDB.Core.Response>;
-    post(db?: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
-    remove(db?: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
-    query(db?: string, fun: any, options?: PouchDB.Query.Options<{}, {}>): Promise<PouchDB.Query.Response<{}>>;
+    get(object: any, db?: string, options?: PouchDB.Core.GetOptions): Promise<any>;
+    put(object: any, db?: string, options?: PouchDB.Core.PutOptions): Promise<PouchDB.Core.Response>;
+    post(object: any, db?: string, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
+    remove(object: any, db?: string, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
+    query(fun: any, db?: string, options?: PouchDB.Query.Options<{}, {}>): Promise<PouchDB.Query.Response<{}>>;
     find(db?: string, options?: PouchDB.Find.FindRequest<{}>): Promise<PouchDB.Find.FindResponse<{}>>;
     createIndex(db?: string, index?: PouchDB.Find.CreateIndexOptions): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
     allDocs(db?: string, options?: PouchDB.Core.AllDocsWithKeyOptions | PouchDB.Core.AllDocsWithKeysOptions | PouchDB.Core.AllDocsWithinRangeOptions | PouchDB.Core.AllDocsOptions): Promise<PouchDB.Core.AllDocsResponse<{}>>;
-    bulkDocs(db?: string, docs: PouchDB.Core.PutDocument<{}>[], options?: PouchDB.Core.BulkDocsOptions): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
+    bulkDocs(docs: PouchDB.Core.PutDocument<{}>[], db?: string, options?: PouchDB.Core.BulkDocsOptions): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
     compact(db?: string, options?: PouchDB.Core.CompactOptions): Promise<PouchDB.Core.Response>;
     viewCleanup(db?: string): Promise<PouchDB.Core.BasicResponse>;
     info(db?: string): Promise<PouchDB.Core.DatabaseInfo>;
-    putAttachment(db?: string, docId: PouchDB.Core.DocumentId, rev: string, attachment: {
+    putAttachment(docId: PouchDB.Core.DocumentId, rev: string, attachment: {
         id: string;
         data: PouchDB.Core.AttachmentData;
         type: string;
-    }): Promise<PouchDB.Core.Response>;
-    getAttachment(db?: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId): Promise<Blob | Buffer>;
-    deleteAttachment(db?: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId, docRev: PouchDB.Core.RevisionId): Promise<PouchDB.Core.RemoveAttachmentResponse>;
+    }, db?: string): Promise<PouchDB.Core.Response>;
+    getAttachment(docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId, db?: string): Promise<Blob | Buffer>;
+    deleteAttachment(docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId, docRev: PouchDB.Core.RevisionId, db?: string): Promise<PouchDB.Core.RemoveAttachmentResponse>;
 }
 declare module 'vue/types/vue' {
     interface VueConstructor {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,42 +15,42 @@ interface PouchVueOptions {
 }
 interface PouchAPI {
     version: string;
-    connect(username: string, password: string, db?: PouchDB.Database): Promise<any>;
-    createUser(username: string, password: string, db?: PouchDB.Database): Promise<any>;
-    putUser(username: string, metadata?: {}, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
-    deleteUser(username: string, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
-    changePassword(username: string, password: string, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
-    changeUsername(oldUsername: string, newUsername: string, db?: PouchDB.Database): Promise<{} | PouchDB.Core.Response>;
-    signUpAdmin(adminUsername: string, adminPassword: string, db?: PouchDB.Database): Promise<string | {}>;
-    deleteAdmin(adminUsername: string, db?: PouchDB.Database): Promise<string | {}>;
-    disconnect(db?: PouchDB.Database): void;
+    connect(username: string, password: string, db?: string): Promise<any>;
+    createUser(username: string, password: string, db?: string): Promise<any>;
+    putUser(username: string, metadata?: {}, db?: string): Promise<{} | PouchDB.Core.Response>;
+    deleteUser(username: string, db?: string): Promise<{} | PouchDB.Core.Response>;
+    changePassword(username: string, password: string, db?: string): Promise<{} | PouchDB.Core.Response>;
+    changeUsername(oldUsername: string, newUsername: string, db?: string): Promise<{} | PouchDB.Core.Response>;
+    signUpAdmin(adminUsername: string, adminPassword: string, db?: string): Promise<string | {}>;
+    deleteAdmin(adminUsername: string, db?: string): Promise<string | {}>;
+    disconnect(db?: string): void;
     destroy(db?: string): void;
     defaults(options?: PouchDB.Configuration.DatabaseConfiguration): void;
     close(db?: string): Promise<void>;
-    getSession(db?: PouchDB.Database): Promise<{}>;
-    sync(localDB: string, remoteDB: string, options?: {}): PouchDB.Replication.Sync<{}>;
-    push(localDB: string, remoteDB: string, options?: {}): PouchDB.Replication.Replication<{}>;
-    pull(localDB: string, remoteDB: string, options?: {}): PouchDB.Replication.Replication<{}>;
-    changes(db: string, options?: {}): PouchDB.Core.Changes<{}>;
-    get(db: string, object: any, options?: PouchDB.Core.GetOptions): Promise<any>;
-    put(db: string, object: any, options?: PouchDB.Core.PutOptions): Promise<PouchDB.Core.Response>;
-    post(db: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
-    remove(db: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
-    query(db: string, fun: any, options?: PouchDB.Query.Options<{}, {}>): Promise<PouchDB.Query.Response<{}>>;
-    find(db: string, options?: PouchDB.Find.FindRequest<{}>): Promise<PouchDB.Find.FindResponse<{}>>;
-    createIndex(db: string, index?: PouchDB.Find.CreateIndexOptions): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
-    allDocs(db: string, options?: PouchDB.Core.AllDocsWithKeyOptions | PouchDB.Core.AllDocsWithKeysOptions | PouchDB.Core.AllDocsWithinRangeOptions | PouchDB.Core.AllDocsOptions): Promise<PouchDB.Core.AllDocsResponse<{}>>;
-    bulkDocs(db: string, docs: PouchDB.Core.PutDocument<{}>[], options?: PouchDB.Core.BulkDocsOptions): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
-    compact(db: string, options?: PouchDB.Core.CompactOptions): Promise<PouchDB.Core.Response>;
-    viewCleanup(db: string): Promise<PouchDB.Core.BasicResponse>;
-    info(db: string): Promise<PouchDB.Core.DatabaseInfo>;
-    putAttachment(db: string, docId: PouchDB.Core.DocumentId, rev: string, attachment: {
+    getSession(db?: string): Promise<{}>;
+    sync(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Sync<{}>;
+    push(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Replication<{}>;
+    pull(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Replication<{}>;
+    changes(db?: string, options?: {}): PouchDB.Core.Changes<{}>;
+    get(db?: string, object: any, options?: PouchDB.Core.GetOptions): Promise<any>;
+    put(db?: string, object: any, options?: PouchDB.Core.PutOptions): Promise<PouchDB.Core.Response>;
+    post(db?: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
+    remove(db?: string, object: any, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
+    query(db?: string, fun: any, options?: PouchDB.Query.Options<{}, {}>): Promise<PouchDB.Query.Response<{}>>;
+    find(db?: string, options?: PouchDB.Find.FindRequest<{}>): Promise<PouchDB.Find.FindResponse<{}>>;
+    createIndex(db?: string, index?: PouchDB.Find.CreateIndexOptions): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
+    allDocs(db?: string, options?: PouchDB.Core.AllDocsWithKeyOptions | PouchDB.Core.AllDocsWithKeysOptions | PouchDB.Core.AllDocsWithinRangeOptions | PouchDB.Core.AllDocsOptions): Promise<PouchDB.Core.AllDocsResponse<{}>>;
+    bulkDocs(db?: string, docs: PouchDB.Core.PutDocument<{}>[], options?: PouchDB.Core.BulkDocsOptions): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
+    compact(db?: string, options?: PouchDB.Core.CompactOptions): Promise<PouchDB.Core.Response>;
+    viewCleanup(db?: string): Promise<PouchDB.Core.BasicResponse>;
+    info(db?: string): Promise<PouchDB.Core.DatabaseInfo>;
+    putAttachment(db?: string, docId: PouchDB.Core.DocumentId, rev: string, attachment: {
         id: string;
         data: PouchDB.Core.AttachmentData;
         type: string;
     }): Promise<PouchDB.Core.Response>;
-    getAttachment(db: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId): Promise<Blob | Buffer>;
-    deleteAttachment(db: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId, docRev: PouchDB.Core.RevisionId): Promise<PouchDB.Core.RemoveAttachmentResponse>;
+    getAttachment(db?: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId): Promise<Blob | Buffer>;
+    deleteAttachment(db?: string, docId: PouchDB.Core.DocumentId, attachmentId: PouchDB.Core.AttachmentId, docRev: PouchDB.Core.RevisionId): Promise<PouchDB.Core.RemoveAttachmentResponse>;
 }
 declare module 'vue/types/vue' {
     interface VueConstructor {


### PR DESCRIPTION
This PR does the following to resolve issue #18 :

1) creates a default parameter of defaultDB for all functions in the public API
2) adds the following lines to all functions so that the defaultDB has a pouch instance:
```
                    if (!databases[db]) {
                        makeInstance(db);
                    }
```
3) Moves all default parameters to the end of the list of non-default parameters for each function. This is a TypeScript requirement with default parameters. It flows well with the API.

4) Updates to the TypeScript declaration files to reflect changes to the API

As a result of these changes we should maybe bump up to 0.3.0

All the unit tests still pass:

```
Pouch options are returned by function
    Unit Tests that todos is defined on Vue components
      √ Test Plugin with Empty Data Function (16ms)
      √ Test Plugin with Empty Data Object (15ms)
      √ Test Plugin with No Data Function Or Object
      √ Test Plugin with Existing Data Function
    Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)
      √ Test Plugin with Empty Data Function
      √ Test Plugin with Empty Data Object
      √ Test Plugin with No Data Function Or Object
      √ Test Plugin with Existing Data Function
  Pouch options are objects
    Unit Tests that todos is defined on Vue components
      √ Test Plugin with Empty Data Function
      √ Test Plugin with Empty Data Object (16ms)
      √ Test Plugin with No Data Function Or Object
      √ Test Plugin with Existing Data Function
    Unit Tests to see that the todos property on the data root level is connected with the todos property on the vue instance (this is what the beforeCreate lifecycle hook does)
      √ Test Plugin with Empty Data Function
      √ Test Plugin with Empty Data Object
      √ Test Plugin with No Data Function Or Object
      √ Test Plugin with Existing Data Function
  Set selector to null
    √ Test Plugin with Reactive Selector that can return null
```
 
It seems necessary to change the API so that we have this consistency with the functions and support a default value for the db used.