### PR TITLE
More Api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ___
 * `$pouch.destroy(OPTIONAL db)`: same as https://pouchdb.com/api.html#delete_database
 * `$pouch.defaults(options)`: same as https://pouchdb.com/api.html#defaults
 ___
-* `$pouch.sync(localDatabase, remoteDatabase, OPTIONAL options)`: Basically the same as PouchDB.sync(local, remote, {live: true, retry: true}). Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server. **BONUS:** If your remote database runs CouchDB 2.0 or higher, you can also specify a Mango Selector that is used to filter documents coming from the remote server. Callback functions will be invoked with the name `pouchdb-[method]-[type]`. So in this case you can use `this.$on('pouchdb-sync-change', callback(data))` to listen when a change occurs. See https://pouchdb.com/api.html#sync for a full list of events you can use.
+* `$pouch.sync(localDatabase, OPTIONAL remoteDatabase, OPTIONAL options)`: The optional remoteDatabase parameter will use the default db set in the pouch options initially. Basically the same as PouchDB.sync(local, remote, {live: true, retry: true}). Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server. **BONUS:** If your remote database runs CouchDB 2.0 or higher, you can also specify a Mango Selector that is used to filter documents coming from the remote server. Callback functions will be invoked with the name `pouchdb-[method]-[type]`. So in this case you can use `this.$on('pouchdb-sync-change', callback(data))` to listen when a change occurs. See https://pouchdb.com/api.html#sync for a full list of events you can use.
 
 **default options (will be merged with the options passed in)**:
  ```
@@ -79,8 +79,8 @@ ___
       });
 
 ```
-* `$pouch.push(localDatabase, remoteDatabase, OPTIONAL options)`: Like https://pouchdb.com/api.html#replication - replicate-to. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
-* `$pouch.pull(localDatabase, remoteDatabase, OPTIONAL options)`: Like https://pouchdb.com/api.html#replication - replicate-from. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
+* `$pouch.push(localDatabase, OPTIONAL remoteDatabase, OPTIONAL options)`: The optional remoteDatabase parameter will use the default db set in the pouch options initially. Like https://pouchdb.com/api.html#replication - replicate-to. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
+* `$pouch.pull(localDatabase, OPTIONAL remoteDatabase, OPTIONAL options)`: The optional remoteDatabase parameter will use the default db set in the pouch options initially. Like https://pouchdb.com/api.html#replication - replicate-from. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
 * `$pouch.changes(OPTIONAL options, OPTIONAL db)`: Listens for change on a db like: https://pouchdb.com/api.html#changes
 * `$pouch.put(object, OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#create_document
 * `$pouch.post(object, OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#create_document

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ All Methods return a promise and mirror or extend the API from pouchdb.
 * `$pouch.signUpAdmin(adminUsername, adminPassword, OPTIONAL db)`: Sign up a new admin and returns response. [pouchdb-authentication API : signUpAdmin](https://github.com/pouchdb-community/pouchdb-authentication/blob/master/docs/api.md#dbsignupadminusername-password--options--callback)
 * `$pouch.deleteAdmin(name, OPTIONAL db)`:Delete an admin and returns response. [pouchdb-authentication API : deleteAdmin](https://github.com/pouchdb-community/pouchdb-authentication/blob/master/docs/api.md#dbdeleteadminusername-opts--callback)
 ___
-* `$pouch.destroy(db)`: same as https://pouchdb.com/api.html#delete_database
+* `$pouch.destroy(OPTIONAL db)`: same as https://pouchdb.com/api.html#delete_database
 * `$pouch.defaults(options)`: same as https://pouchdb.com/api.html#defaults
 ___
-* `$pouch.sync(localDatabase, remoteDatabase, options)`: Basically the same as PouchDB.sync(local, remote, {live: true, retry: true}). Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server. **BONUS:** If your remote database runs CouchDB 2.0 or higher, you can also specify a Mango Selector that is used to filter documents coming from the remote server. Callback functions will be invoked with the name `pouchdb-[method]-[type]`. So in this case you can use `this.$on('pouchdb-sync-change', callback(data))` to listen when a change occurs. See https://pouchdb.com/api.html#sync for a full list of events you can use.
+* `$pouch.sync(localDatabase, remoteDatabase, OPTIONAL options)`: Basically the same as PouchDB.sync(local, remote, {live: true, retry: true}). Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server. **BONUS:** If your remote database runs CouchDB 2.0 or higher, you can also specify a Mango Selector that is used to filter documents coming from the remote server. Callback functions will be invoked with the name `pouchdb-[method]-[type]`. So in this case you can use `this.$on('pouchdb-sync-change', callback(data))` to listen when a change occurs. See https://pouchdb.com/api.html#sync for a full list of events you can use.
 
 **default options (will be merged with the options passed in)**:
  ```
@@ -79,22 +79,25 @@ ___
       });
 
 ```
-* `$pouch.push(localDatabase, remoteDatabase, options)`: Like https://pouchdb.com/api.html#replication - replicate-to. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
-* `$pouch.pull(localDatabase, remoteDatabase, options)`: Like https://pouchdb.com/api.html#replication - replicate-from. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
-* `$pouch.changes(database, options)`: Listens for change on a db like: https://pouchdb.com/api.html#changes
-* `$pouch.put/post/remove/get(database, ...)`: Same as db.put/post/remove/get(...) https://pouchdb.com/api.html#create_document
-* `$pouch.query(db, 'map/reduce function', options)`: like https://pouchdb.com/api.html#query_database
-* `$pouch.allDocs(db, options)`: like https://pouchdb.com/api.html#batch_fetch but `include_docs` is set to true by default. You can however overwrite it of course.
-* `$pouch.bulkDocs(db, options)`: https://pouchdb.com/api.html#batch_create
-* `$pouch.compact(db, options)`: https://pouchdb.com/api.html#compaction
-* `$pouch.viewCleanup(db)`: https://pouchdb.com/api.html#view_cleanup
-* `$pouch.info(db)`: like https://pouchdb.com/api.html#database_information
-* `$pouch.find(db, request)`: like https://pouchdb.com/api.html#query_index
-* `$pouch.createIndex(db, index)`: like https://pouchdb.com/api.html#create_index
-* `$pouch.putAttachment(db, docId, [rev], attachmentObject(id,data,type)`: like https://pouchdb.com/api.html#save_attachment
-* `$pouch.getAttachment(db, docId, attachmentId)`: like https://pouchdb.com/api.html#get_attachment
-* `$pouch.deleteAttachment(db, docId, attachmentId, docRev)`: like https://pouchdb.com/api.html#delete_attachment
-* `$pouch.close(db)`: https://pouchdb.com/api.html#close_database
+* `$pouch.push(localDatabase, remoteDatabase, OPTIONAL options)`: Like https://pouchdb.com/api.html#replication - replicate-to. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
+* `$pouch.pull(localDatabase, remoteDatabase, OPTIONAL options)`: Like https://pouchdb.com/api.html#replication - replicate-from. Also, if the browser has an active session cookie, it will fetch session data (username, etc) from the remote server.
+* `$pouch.changes(OPTIONAL options, OPTIONAL db)`: Listens for change on a db like: https://pouchdb.com/api.html#changes
+* `$pouch.put(object, OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#create_document
+* `$pouch.post(object, OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#create_document
+* `$pouch.remove(object, OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#create_document
+* `$pouch.get(object, OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#create_document
+* `$pouch.query('map/reduce function', OPTIONAL options, OPTIONAL db)`: like https://pouchdb.com/api.html#query_database
+* `$pouch.allDocs(OPTIONAL options, OPTIONAL db)`: like https://pouchdb.com/api.html#batch_fetch but `include_docs` is set to true by default. You can however overwrite it of course.
+* `$pouch.bulkDocs(docs, OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#batch_create
+* `$pouch.compact(OPTIONAL options, OPTIONAL db)`: https://pouchdb.com/api.html#compaction
+* `$pouch.viewCleanup(OPTIONAL db)`: https://pouchdb.com/api.html#view_cleanup
+* `$pouch.info(OPTIONAL db)`: like https://pouchdb.com/api.html#database_information
+* `$pouch.find(request, OPTIONAL db)`: like https://pouchdb.com/api.html#query_index
+* `$pouch.createIndex(index, OPTIONAL db)`: like https://pouchdb.com/api.html#create_index
+* `$pouch.putAttachment(docId, [rev], attachmentObject(id,data,type), OPTIONAL db)`: like https://pouchdb.com/api.html#save_attachment
+* `$pouch.getAttachment(docId, attachmentId, OPTIONAL db)`: like https://pouchdb.com/api.html#get_attachment
+* `$pouch.deleteAttachment(docId, attachmentId, docRev, OPTIONAL db)`: like https://pouchdb.com/api.html#delete_attachment
+* `$pouch.close(OPTIONAL db)`: https://pouchdb.com/api.html#close_database
 
 #### Non-Reactive Properties
 * `vm.$databases`: the pouchdb instances which are shared across all components.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pouch-vue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "PouchDB bindings for Vue.js",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -543,7 +543,7 @@ import { isRemote } from 'pouchdb-utils';
                     return rep;
                 },
 
-                changes(db=defaultDB, options = {}) {
+                changes(options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -590,42 +590,42 @@ import { isRemote } from 'pouchdb-utils';
                     return changes;
                 },
 
-                get(object, db=defaultDB, options = {}) {
+                get(object, options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].get(object, options);
                 },
 
-                put(object, db=defaultDB, options = {}) {
+                put(object, options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].put(object, options);
                 },
 
-                post(object, db=defaultDB, options = {}) {
+                post(object, options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].post(object, options);
                 },
 
-                remove(object, db=defaultDB, options = {}) {
+                remove(object, options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].remove(object, options);
                 },
 
-                query(fun, db=defaultDB, options = {}) {
+                query(fun, options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
                     return databases[db].query(fun, options);
                 },
 
-                find(db=defaultDB, options = {}) {
+                find(options, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -633,7 +633,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].find(options);
                 },
 
-                createIndex(db=defaultDB, index = {}) {
+                createIndex(index, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -641,7 +641,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].createIndex(index);
                 },
 
-                allDocs(db=defaultDB, options = {}) {
+                allDocs(options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -655,7 +655,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].allDocs(_options);
                 },
 
-                bulkDocs(docs, db=defaultDB, options = {}) {
+                bulkDocs(docs, options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }
@@ -663,7 +663,7 @@ import { isRemote } from 'pouchdb-utils';
                     return databases[db].bulkDocs(docs, options);
                 },
 
-                compact(db=defaultDB, options = {}) {
+                compact(options = {}, db=defaultDB) {
                     if (!databases[db]) {
                         makeInstance(db);
                     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,17 +31,17 @@ interface PouchAPI {
     sync(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Sync<{}>;
     push(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Replication<{}>;
     pull(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Replication<{}>;
-    changes(db?: string, options?: {}): PouchDB.Core.Changes<{}>;
-    get(object: any, db?: string, options?: PouchDB.Core.GetOptions): Promise<any>;
-    put(object: any, db?: string, options?: PouchDB.Core.PutOptions): Promise<PouchDB.Core.Response>;
-    post(object: any, db?: string, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
-    remove(object: any, db?: string, options?: PouchDB.Core.Options): Promise<PouchDB.Core.Response>;
-    query(fun: any, db?: string, options?: PouchDB.Query.Options<{}, {}>): Promise<PouchDB.Query.Response<{}>>;
-    find(db?: string, options?: PouchDB.Find.FindRequest<{}>): Promise<PouchDB.Find.FindResponse<{}>>;
-    createIndex(db?: string, index?: PouchDB.Find.CreateIndexOptions): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
-    allDocs(db?: string, options?: PouchDB.Core.AllDocsWithKeyOptions | PouchDB.Core.AllDocsWithKeysOptions | PouchDB.Core.AllDocsWithinRangeOptions | PouchDB.Core.AllDocsOptions): Promise<PouchDB.Core.AllDocsResponse<{}>>;
-    bulkDocs(docs: PouchDB.Core.PutDocument<{}>[], db?: string, options?: PouchDB.Core.BulkDocsOptions): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
-    compact(db?: string, options?: PouchDB.Core.CompactOptions): Promise<PouchDB.Core.Response>;
+    changes(options?: {}, db?: string): PouchDB.Core.Changes<{}>;
+    get(object: any, options?: PouchDB.Core.GetOptions, db?: string): Promise<any>;
+    put(object: any, options?: PouchDB.Core.PutOptions, db?: string): Promise<PouchDB.Core.Response>;
+    post(object: any, options?: PouchDB.Core.Options, db?: string): Promise<PouchDB.Core.Response>;
+    remove(object: any, options?: PouchDB.Core.Options, db?: string): Promise<PouchDB.Core.Response>;
+    query(fun: any, options?: PouchDB.Query.Options<{}, {}>, db?: string): Promise<PouchDB.Query.Response<{}>>;
+    find(options?: PouchDB.Find.FindRequest<{}>, db?: string): Promise<PouchDB.Find.FindResponse<{}>>;
+    createIndex(index?: PouchDB.Find.CreateIndexOptions, db?: string): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
+    allDocs(options?: PouchDB.Core.AllDocsWithKeyOptions | PouchDB.Core.AllDocsWithKeysOptions | PouchDB.Core.AllDocsWithinRangeOptions | PouchDB.Core.AllDocsOptions, db?: string): Promise<PouchDB.Core.AllDocsResponse<{}>>;
+    bulkDocs(docs: PouchDB.Core.PutDocument<{}>[], options?: PouchDB.Core.BulkDocsOptions, db?: string): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
+    compact(options?: PouchDB.Core.CompactOptions, db?: string): Promise<PouchDB.Core.Response>;
     viewCleanup(db?: string): Promise<PouchDB.Core.BasicResponse>;
     info(db?: string): Promise<PouchDB.Core.DatabaseInfo>;
     putAttachment(docId: PouchDB.Core.DocumentId, rev: string, attachment: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ interface PouchAPI {
     deleteAdmin(adminUsername: string, db?: string): Promise<string | {}>;
     disconnect(db?: string): void;
     destroy(db?: string): void;
-    defaults(options?: PouchDB.Configuration.DatabaseConfiguration): void;
+    defaults(options: PouchDB.Configuration.DatabaseConfiguration): void;
     close(db?: string): Promise<void>;
     getSession(db?: string): Promise<{}>;
     sync(localDB: string, remoteDB?: string, options?: {}): PouchDB.Replication.Sync<{}>;
@@ -37,8 +37,8 @@ interface PouchAPI {
     post(object: any, options?: PouchDB.Core.Options, db?: string): Promise<PouchDB.Core.Response>;
     remove(object: any, options?: PouchDB.Core.Options, db?: string): Promise<PouchDB.Core.Response>;
     query(fun: any, options?: PouchDB.Query.Options<{}, {}>, db?: string): Promise<PouchDB.Query.Response<{}>>;
-    find(options?: PouchDB.Find.FindRequest<{}>, db?: string): Promise<PouchDB.Find.FindResponse<{}>>;
-    createIndex(index?: PouchDB.Find.CreateIndexOptions, db?: string): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
+    find(options: PouchDB.Find.FindRequest<{}>, db?: string): Promise<PouchDB.Find.FindResponse<{}>>;
+    createIndex(index: PouchDB.Find.CreateIndexOptions, db?: string): Promise<PouchDB.Find.CreateIndexResponse<{}>>;
     allDocs(options?: PouchDB.Core.AllDocsWithKeyOptions | PouchDB.Core.AllDocsWithKeysOptions | PouchDB.Core.AllDocsWithinRangeOptions | PouchDB.Core.AllDocsOptions, db?: string): Promise<PouchDB.Core.AllDocsResponse<{}>>;
     bulkDocs(docs: PouchDB.Core.PutDocument<{}>[], options?: PouchDB.Core.BulkDocsOptions, db?: string): Promise<(PouchDB.Core.Response | PouchDB.Core.Error)[]>;
     compact(options?: PouchDB.Core.CompactOptions, db?: string): Promise<PouchDB.Core.Response>;


### PR DESCRIPTION
Part of the design of this Vue.js plugin is to have a default DB specified. Given this design priority I've modified all the functions of the api to be able to function without specifying the parameter db. This requires that the db parameter is the last parameter.

The only edge cases are with sync, push, and pull where the db parameter is the second to last parameter since it seemed strange to not have the remoteDB parameter follow the localDB parameter. So, you could leave out the remoteDB parameter and use the defaultdb but then you can't also specify options. So $pouch.push('todos') or $pouch.sync('todos') will work fine and use the default remoteDB, but you can't specify options, e.g $pouch.push('todos', options') or $pouch.sync('todos', options). If you wanted to specify options, then you need to specify the remoteDB parameter as well.

What's required now is that the plugin requires the defaultDB parameter to be set. If not, it gives a warning.
