### PR TITLE
Fix Issue #22 part 3 and a regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pouch-vue",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "PouchDB bindings for Vue.js",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -103,8 +103,16 @@ import { isRemote } from 'pouchdb-utils';
                 });
             }
 
-            function makeInstance(db, opts = {}) {
-                databases[db] = new pouch(db, opts);
+            function makeInstance(db, options = {}) {
+                // merge default DB options with those passed in
+            
+                let _options = Object.assign(
+                    {},
+                    optionsDB,
+                    options
+                )
+
+                databases[db] = new pouch(db, _options);
                 registerListeners(databases[db]);
             }
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ import { isRemote } from 'pouchdb-utils';
             vm._liveFeeds = {};
 
             if (defaultDB) {
-                makeInstance(defaultDB, optionsDB);
+                makeInstance(defaultDB);
             }
 
             function fetchSession(db = databases[defaultDB]) {
@@ -104,7 +104,13 @@ import { isRemote } from 'pouchdb-utils';
             }
 
             function makeInstance(db, options = {}) {
-                // merge default DB options with those passed in
+                // Merge the plugin optionsDB options with those passed in
+                // when creating pouch dbs.
+                // Note: default opiontsDB options are passed in when creating 
+                // both local and remote pouch databases. E.g. modifying fetch()
+                // in the options is only useful for remote Dbs but will be passed
+                // for local pouch dbs too if set in optionsDB.
+                // See: https://pouchdb.com/api.html#create_database
             
                 let _options = Object.assign(
                     {},
@@ -326,26 +332,26 @@ import { isRemote } from 'pouchdb-utils';
                         makeInstance(localDB);
                     }
                     if (!databases[remoteDB]) {
-                        makeInstance(remoteDB, optionsDB);
+                        makeInstance(remoteDB);
                     }
                     if (!defaultDB) {
                         defaultDB = remoteDB;
                     }
 
                     let _options = Object.assign(
-                            {},
-                            {
-                                live: true,
-                                retry: true,
-                                back_off_function: delay => {
-                                    if (delay === 0) {
-                                        return 1000;
-                                    }
-                                    return delay * 3;
-                                },
+                        {},
+                        {
+                            live: true,
+                            retry: true,
+                            back_off_function: delay => {
+                                if (delay === 0) {
+                                    return 1000;
+                                }
+                                return delay * 3;
                             },
-                            options
-                        )
+                        },
+                        options
+                    );
 
                     let sync = pouch
                         .sync(databases[localDB], databases[remoteDB], _options)
@@ -407,6 +413,24 @@ import { isRemote } from 'pouchdb-utils';
                     if (!databases[remoteDB]) {
                         makeInstance(remoteDB);
                     }
+                    if (!defaultDB) {
+                        defaultDB = remoteDB;
+                    }
+
+                    let _options = Object.assign(
+                        {},
+                        {
+                            live: true,
+                            retry: true,
+                            back_off_function: delay => {
+                                if (delay === 0) {
+                                    return 1000;
+                                }
+                                return delay * 3;
+                            },
+                        },
+                        options
+                    );
 
                     let rep = databases[localDB].replicate
                         .to(databases[remoteDB], options)
@@ -468,6 +492,24 @@ import { isRemote } from 'pouchdb-utils';
                     if (!databases[remoteDB]) {
                         makeInstance(remoteDB);
                     }
+                    if (!defaultDB) {
+                        defaultDB = remoteDB;
+                    }
+
+                    let _options = Object.assign(
+                        {},
+                        {
+                            live: true,
+                            retry: true,
+                            back_off_function: delay => {
+                                if (delay === 0) {
+                                    return 1000;
+                                }
+                                return delay * 3;
+                            },
+                        },
+                        options
+                    );
 
                     let rep = databases[localDB].replicate
                         .from(databases[remoteDB], options)
@@ -528,19 +570,19 @@ import { isRemote } from 'pouchdb-utils';
                     }
 
                     let _options = Object.assign(
-                            {},
-                            {
-                                live: true,
-                                retry: true,
-                                back_off_function: delay => {
-                                    if (delay === 0) {
-                                        return 1000;
-                                    }
-                                    return delay * 3;
-                                },
+                        {},
+                        {
+                            live: true,
+                            retry: true,
+                            back_off_function: delay => {
+                                if (delay === 0) {
+                                    return 1000;
+                                }
+                                return delay * 3;
                             },
-                            options
-                        )
+                        },
+                        options
+                    );
 
                     let changes = databases[db]
                         .changes(_options)

--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,6 @@ import { isRemote } from 'pouchdb-utils';
 
             vm._liveFeeds = {};
 
-            let pouchOptions = this.$options.pouch;
-            if (!pouchOptions) return;
-            if (typeof pouchOptions === 'function') pouchOptions = pouchOptions();
-
             if (defaultDB) {
                 makeInstance(defaultDB, optionsDB);
             }
@@ -700,6 +696,16 @@ import { isRemote } from 'pouchdb-utils';
             vm.$pouch = $pouch;
             //add non reactive property
             vm.$databases = databases; // Add non-reactive property
+
+            let pouchOptions = this.$options.pouch;
+
+            if (!pouchOptions) {
+                return;
+            }
+
+            if (typeof pouchOptions === 'function') {
+                pouchOptions = pouchOptions();
+            }
 
             Object.keys(pouchOptions).map(key => {
                 let pouchFn = pouchOptions[key];


### PR DESCRIPTION
This PR continues to bring more consistency to the API with default options for push and pull matching sync now (issue #22). Also, moving the optionsDB of the plugin into makeInstance() instead of only being applied by sync. This means that optionsDB is passed into all created databases even if those databases are local and don't require the remote options, or remote and don't require the local options. If there's a local option or a remote option that you want applied to only a single database, then don't put it in the optionsDB. If you had two remote databases and wanted to only modify the fetch method for one of those remote databases, then you wouldn't do it with optionsDB. For context:

```
Vue.use(pouchVue,{
  pouch: PouchDB,
  defaultDB: 'todos',
  optionsDB: {
    fetch: function (url:any, opts:any) {
        opts.credentials = 'include';
        return PouchDB.fetch(url, opts);
    }    
  }
})  
```

Seems like this shouldn't be an issue since options for remote and local databases mostly don't overlap and will just be ignored if not applicable. The only option that does overlap is 'name' (https://pouchdb.com/api.html#create_database)

Also, a regression was introduced by moving the pouchOptions check before the api is created and returning early if no pouchOptions are found. It seemed mostly harmless, but had an unintended consequence. If there are no pouchOptions, then the api isn't created. Interestingly, there is a project that separates the api from the liveFind portion. In [project Boatnet](https://github.com/nwfsc-fram/boatnet) the api is placed in a [service layer](https://github.com/nwfsc-fram/boatnet/blob/master/libs/bn-pouch/src/_services/pouch.service.ts) with no pouchOptions found, and then the service layer is called from other components where the pouchOptions have been specified and so liveFind works off of that.

The reason project Boatnet uses a service layer ([wrapped in a vuex store](https://github.com/nwfsc-fram/boatnet/blob/master/libs/bn-pouch/src/_store/pouch.module.ts) which is then loaded as a module in the [main vuex store](https://github.com/nwfsc-fram/boatnet/blob/master/apps/obs-web/src/_store/index.ts)) is so that some events (e.g. pouchdb-sync-update) can be captured and used to emit other custom events that determine Sync status. Then pouch component options are applied on other components. At least that's how I understand it from testing their code.
