### PR TITLE
Remove inconsequential calls to fetchSession()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pouch-vue",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "PouchDB bindings for Vue.js",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -797,7 +797,6 @@ import { isRemote } from 'pouchdb-utils';
                         } else if (typeof databaseParam === 'string') {
                             if (!databases[databaseParam]) {
                                 makeInstance(databaseParam);
-                                login(databases[databaseParam]);
                             }
                             db = databases[databaseParam];
                         }

--- a/src/index.js
+++ b/src/index.js
@@ -402,8 +402,6 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
 
-                    fetchSession(databases[remoteDB]);
-
                     return sync;
                 },
                 push(localDB, remoteDB=defaultDB, options = {}) {
@@ -479,8 +477,6 @@ import { isRemote } from 'pouchdb-utils';
                                 error: err,
                             });
                         });
-
-                    fetchSession(databases[remoteDB]);
 
                     return rep;
                 },
@@ -559,8 +555,6 @@ import { isRemote } from 'pouchdb-utils';
                             });
                         });
 
-                    fetchSession(databases[remoteDB]);
-
                     return rep;
                 },
 
@@ -604,8 +598,6 @@ import { isRemote } from 'pouchdb-utils';
                                 error: err,
                             });
                         });
-
-                    fetchSession(databases[db]);
 
                     return changes;
                 },

--- a/tests/testData.spec.js
+++ b/tests/testData.spec.js
@@ -208,7 +208,7 @@ describe('Set selector to null', () => {
       // trip up the watcher on the pouch database config options
       let selector = function () { return (this.age < this.maxAge) ? null : {} }
 
-      function testFunc() {
+      function testFunc(done) {
         const localVue = createLocalVue()
 
         // add requisite PouchDB plugins
@@ -232,7 +232,13 @@ describe('Set selector to null', () => {
         wrapper.vm.todos = ['north', 'east', 'south', 'west'];
 
         wrapper.vm.maxAge = 50;
-        expect(wrapper.emitted('pouchdb-livefeed-error')).toHaveLength(1);
+          
+        //watchers are deferred to the next update cycle that Vue uses to look for changes.
+        //the change to the selector has a watcher on it in pouch-vue
+        wrapper.vm.$nextTick(() => {  
+          expect(wrapper.emitted('pouchdb-livefeed-error')).toHaveLength(1);
+          done();
+        });            
       }
       test(tryTestName, testFunc);
     }


### PR DESCRIPTION
This is a PR for the issue I raised in #34. In the sync, pull, push, and changes functions, there is a call to fetchSession() that returns a promise but nothing is being done with the returned promise. The fetchSession() method doesn't seem to have any side effects that would be useful after the sync, pull, push, or changes calls on the db. It seems to be inconsequential code, so I suggest removing it with this PR.