### PR TITLE
Fix Documentation that results in an error when implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Install via npm:
 The only requirement is that `pouchdb-live-find` is installed:
 ```
     import PouchDB from 'pouchdb-browser'
-    PouchDB.plugin(require('pouchdb-find'));
-    PouchDB.plugin(require('pouchdb-live-find'));
+    import PouchFind from 'pouchdb-find'
+    import PouchLiveFind from 'pouchdb-live-find'
+    
+    PouchDB.plugin(PouchFind)
+    PouchDB.plugin(PouchLiveFind)
 ```
 
 If you want to use remote databases (CouchDB, Cloudant, etc.), you should also install the authentication plugin:


### PR DESCRIPTION
Fixes documentation resulting in [this issue](https://github.com/colinskow/pouchdb-live-find/issues/11):
`PouchDB Find is a requirement for LiveFind and must be loaded first.`